### PR TITLE
Blocking private chat & Creating solution for deleted account

### DIFF
--- a/src/dev_bot.py
+++ b/src/dev_bot.py
@@ -26,10 +26,13 @@ class DevBot:
 
     def run_bot(self):
         async def check_name_member(chatid, userid):
-            member = await bot.get_chat_member(chat_id=str(chatid), user_id=str(userid))
-            name_member = member['user']['first_name']
-            if ("last_name" in member['user']): name_member += member['user']['last_name']
-            return name_member
+            try:
+                member = await bot.get_chat_member(chat_id=str(chatid), user_id=str(userid))
+                name_member = member['user']['first_name']
+                if ("last_name" in member['user']): f"{name_member} {member['user']['last_name']}"
+                return name_member
+            except:
+                return "Conta Excluida"
             
         @self.dispatcher.message_handler(commands=['exp'])
         async def exp(message: types.Message):

--- a/src/dev_bot.py
+++ b/src/dev_bot.py
@@ -47,5 +47,6 @@ class DevBot:
         @self.dispatcher.message_handler()
         async def listening(message: types.Message):
             await random_response(message)
-            await self.database.update(message)
-            await self.experience.handler(message)
+            if (message.chat.type != "private"):
+                await self.database.update(message)
+                await self.experience.handler(message)


### PR DESCRIPTION
**Qual o propósito deste pull request?**
- [Informar algo alternativo, caso o método que usamos da API, informe que o usuário tenha deletado a conta](https://trello.com/c/zicdddQz/36-exece%C3%A7%C3%B5es-para-erros-da-api)
- [Bloquear conversar privadas](https://trello.com/c/PwAtchsE/35-n%C3%A3o-salvar-conversa-privada)

**O que foi feito para atingir esse propósito?**
- Para resolver o primeiro problema [foi criado um teste de verificação, em caso de problemas no teste, ele irá informar que a conta do usuário foi excluída](https://github.com/GrupoDevelopers/DevBot/commit/68806af936f2b7e221a34b8434362124c595e557)
 Estou tratando desta forma, pois esse método do telegram não tem erros, apenas em caso de exclusão
- Para resolver o segundo problema [foi criado uma condição que verifica se o chat não é privado, caso seja ele não fara nada](https://github.com/GrupoDevelopers/DevBot/commit/d1748e13b170fac38ca323ef1f5a20d175fdec2e)
Extra: [Corrigir o problema de nome e sobrenome aglutinado.](https://github.com/GrupoDevelopers/DevBot/commit/68806af936f2b7e221a34b8434362124c595e557#diff-5dd378e6259c9b3c4f3a222a6b5155bbR32)
 